### PR TITLE
Fix issue with .LBB labels

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ rustc-demangle = "0.1.16"
 structopt = "0.3"
 clap = { version = "2.33", default-features = false }
 regex = "1"
+once_cell = "1.17.1"
 
 [dependencies.haybale]
 git = "https://github.com/hudson-ayers/haybale"

--- a/src/instruction_counter.rs
+++ b/src/instruction_counter.rs
@@ -44,7 +44,7 @@ pub fn get_disassembly(bc_dir: &String, board_name: &String) -> Disassem {
 fn build_func_and_bb_patterns(location: &Location) -> (Regex, Regex) {
     // matches the start of the desired function
     let func_name = &location.func.name;
-    let func_pat = format!(r"^{}:$", func_name);
+    let func_pat = format!(r"^{}:$", regex::escape(func_name));
     let func_re = Regex::new(&func_pat).unwrap();
 
     // matches the start of the desired bb
@@ -62,7 +62,7 @@ fn build_func_and_bb_patterns(location: &Location) -> (Regex, Regex) {
             Err(_) => panic!("cannot parse int: {}", num_str),
         }
     } else if bb_exit_pat.is_match(bb_name) {
-        format!(r"^.*(@ {}).*$", bb_name)
+        format!(r"^.*(@ {}).*$", regex::escape(bb_name))
     } else {
         panic!("bb name format not recognized: {}", bb_name);
     };


### PR DESCRIPTION
Fixed a bug with the search function running off the end of a function. And also fixed the BB pattern matching to include .LBB labels.

At this point, my manual inspection seems to show that BBs that still cannot be found actually does not exist in the final binary.